### PR TITLE
Implementando websockets e exemplo de mudança no esquema de leitura das portas.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,7 +398,7 @@ void loop() {
       {
         Serial.println(estadoPortaAberta.c_str());
         delay(30);
-        estadoAnteriorPortaAberta = estadoPortaAberta;//#include <ESPAsyncWebServer.h>
+        estadoAnteriorPortaAberta = estadoPortaAberta;
       }
     }
     else

--- a/src/websockets.h
+++ b/src/websockets.h
@@ -1,0 +1,2 @@
+const char* websockets_server_host = "changeme";
+const uint16_t websockets_server_port = 12345;

--- a/src/wifi.h
+++ b/src/wifi.h
@@ -1,0 +1,2 @@
+const char* ssid = "Telemetria";
+const char* passwd = "esp32pass";


### PR DESCRIPTION
1. Removendo bibliotecas que não estão sendo utilizadas.
2. Dois arquivos de cabeçalho para o websockets e wifi.
3. Exemplo de como será lido os dados das portas no `pinSetaEsquerda`.
4. Desabilitando o pull up porque a ligação elétrica na porta 4 do optoacoplador já opera como um pull down, eliminando os ruídos.